### PR TITLE
Add support for configuring the ESP with static IP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Prerequisites:
 - You need an ESP8266 device. This has been tested on the Wemos D1 Mini & Adafruit Huzzah.
 - The ESP8266 must be running MicroPython. 
 
-Copy `boot.py`, `main.py`, and `config.py` to the device's flash. I recommend using [mpfshell](https://github.com/wendlers/mpfshell) to do this. To enable relevant messages from the updater or during boot (e.g. on wifi connect), edit `config.py` and set `SILENT = False`
+Copy `boot.py`, `main.py`, and `config.py` to the device's flash. I recommend using [mpfshell](https://github.com/wendlers/mpfshell) to do this. To enable relevant messages from the updater or during boot (e.g. on wifi connect), edit `config.py` and set `SILENT = False`. To set a static IP addres, uncomment and edit the variables `IP`, `SUBNET`, `GATEWAY` and `DNS`.
 
 Create a `secrets.py` file in the following format, and copy to the device's flash:
 ```

--- a/boot.py
+++ b/boot.py
@@ -16,6 +16,13 @@ def do_connect():
         a_if.active(False)
     if not s_if.isconnected():
         s_if.active(True)
+        # Set static IP if configured.
+        try:
+            s_if.ifconfig((config.IP, config.SUBNET, config.GATEWAY, config.DNS))
+        except:
+            if not config.SILENT:
+                print("Static IP not configured. Setting IP via DHCP.")
+        # Connect to Wifi.
         s_if.connect(secrets.WIFI_SSID, secrets.WIFI_PASSPHRASE)
         while not s_if.isconnected():
             pass

--- a/config.py
+++ b/config.py
@@ -1,2 +1,8 @@
 # If set, writing to serial console will be minimized
 SILENT = True
+
+# Set the values below to initiate the network interface with a static IP.
+#IP = "192.168.0.123"
+#SUBNET = "255.255.255.0" # aka Netmask
+#GATEWAY = "192.168.0.1"
+#DNS = "8.8.8.8"


### PR DESCRIPTION
This change will allow `boot.py` to initialize the network interface with a static IP, if configured.
It adds an example to `config.py` and mentions it in the README.